### PR TITLE
fix inputmap

### DIFF
--- a/nix/project.nix
+++ b/nix/project.nix
@@ -8,7 +8,7 @@ let
     compiler-nix-name = lib.mkDefault "ghc96";
     shell.withHoogle = false;
     inputMap = {
-      "https://input-output-hk.github.io/cardano-haskell-packages" = inputs.iogx.inputs.CHaP;
+      "https://chap.intersectmbo.org/" = inputs.iogx.inputs.CHaP;
     };
     modules = [{
       packages = {


### PR DESCRIPTION
Fixed the inputmap to correspond to the new route
`inputMap = {
      "https://chap.intersectmbo.org/" = inputs.iogx.inputs.CHaP;
    };`